### PR TITLE
Problem: compiles/passes-tests/works properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,6 @@ unsupported-features = ["server"]
 
 # This allows to specify fine-grained indication of readiness per target
 [package.metadata.wasm.rs.target.'wasm32-unknown-unknown']
-# Default: `true` (if the target is listed in `package.metadata.wasm.rs.targets), otherwise `false`)
-compiles = true
-# Default: `true` (if the target is listed in `package.metadata.wasm.rs.targets), otherwise `false`)
-passes-tests = false
-# Default: `true` (if the target is listed in `package.metadata.wasm.rs.targets), otherwise `false`)
-works = true
 # A string that can be used to describe limitations
 limited-functionality = "certain functionality is disabled"
 


### PR DESCRIPTION
As stated in https://github.com/wasm-rs/cargo-metadata/issues/2

<blockquote>
The targets key under [package.metadata.wasm.rs] lets us specify which wasm targets are supported. It seems to me that stating that a specific target is supported should be a strong enough statement, which conflicts with the ability to specify the fine-grained indicators. Examples:

Does it make sense that wasm32-unknown-unknown is supported but compiles = false?
Does it make sense that wasm32-unknown-unknown is supported but works = false?
It might make sense that a target is supported but the tests don't pass because of (e.g. there is some issue causing a test to fail on wasm32-unknown-unknown but in practice the crate works), but I feel this too is not really needed.

Additionally, is there a real need to specify compiles and passes-tests if these values can actually be computed by attempting to compile and to run the tests?
</blockquote>

Solution: remove these properties

Fixes #2 