### PR TITLE
Adding the `wasm-readme` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ required-features = ["wasm"]
 # (default: `[]`)
 unsupported-features = ["server"]
 
+# The `wasm-readme` field should be the path to a file in the package root (relative to this Cargo.toml) ,
+# that contains information about the package's support for WebAssembly, such as limitations and behavioral differences. 
+# wasm.rs will interpret it as Markdown and render it on the crate's page.
+wasm-readme = "README_WASM.md"
+
 # This allows to specify fine-grained indication of readiness per target
 [package.metadata.wasm.rs.target.'wasm32-unknown-unknown']
 # A string that can be used to describe limitations

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ unsupported-features = ["server"]
 # The `wasm-readme` field should be the path to a file in the package root (relative to this Cargo.toml) ,
 # that contains information about the package's support for WebAssembly, such as limitations and behavioral differences. 
 # wasm.rs will interpret it as Markdown and render it on the crate's page.
+# (This field is optional)
 wasm-readme = "README_WASM.md"
 
 # This allows to specify fine-grained indication of readiness per target


### PR DESCRIPTION
Adding the `wasm-readme` field which lets crate authors add a markdown file with details of their crate's WASM support.
This file, if present, will be rendered on the crate's page in wasm.rs

(Implementation of #5 ) 