### PR TITLE
Compatibility indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ required-features = ["wasm"]
 # (default: `[]`)
 unsupported-features = ["server"]
 
+# Indicates the minimum WebAssembly version that must be supported by the host in order for this crate to function properly.
+# (default: `"1.0"`)
+min-wasm-version = "1.0"
+
+# A list of WebAssembly features that must be supported by the host in order for this crate to function properly.
+# The names of the features are the names of the respective GitHub repositories that contain the WebAssembly spec proposals. 
+# (default: `[]`)
+required-wasm-features = ["threads", "simd", "reference-types", "multi-value"]
+
 # The `wasm-readme` field should be the path to a file in the package root (relative to this Cargo.toml) ,
 # that contains information about the package's support for WebAssembly, such as limitations and behavioral differences. 
 # wasm.rs will interpret it as Markdown and render it on the crate's page.

--- a/README.md
+++ b/README.md
@@ -32,13 +32,23 @@ min-wasm-version = "1.0"
 # A list of WebAssembly features that must be supported by the host in order for this crate to function properly.
 # The names of the features are the names of the respective GitHub repositories that contain the WebAssembly spec proposals. 
 # (default: `[]`)
-required-wasm-features = ["threads", "simd", "reference-types", "multi-value"]
+required-wasm-features = ["simd", "reference-types", "multi-value"]
 
 # The `wasm-readme` field should be the path to a file in the package root (relative to this Cargo.toml) ,
 # that contains information about the package's support for WebAssembly, such as limitations and behavioral differences. 
 # wasm.rs will interpret it as Markdown and render it on the crate's page.
 # (This field is optional)
 wasm-readme = "README_WASM.md"
+
+# This sections allows specifying dependencies between crate features and WebAssembly features.
+# The names of the features are the names of the respective GitHub repositories that contain the WebAssembly spec proposals. 
+[package.metadata.wasm.rs.features]
+
+# This example indicates that the `parallelization` feature of this crate requires the host to support the `threads` and `bulk-memory-operations` WebAssembly features,
+# and the `global-state` crate feature requires the `mutable-global` WebAssembly feature,
+# in addition to the features specified by the `required-wasm-features` field.
+parallelization = ["threads", "atomics", "bulk-memory-operations"]
+global-state = ["mutable-global"]
 
 # This allows to specify fine-grained indication of readiness per target
 [package.metadata.wasm.rs.target.'wasm32-unknown-unknown']


### PR DESCRIPTION
Addresses #7 

- Allow author to specify minimum required WASM version
- Allow author to specify required WASM features
  - Globally for the entire crate
  - For specific crate features 

Not providing support for per-target fine-grained indicators at this point: while it is technically possible to have a dependency on a specific WASM feature only for a specific WASM target, at this point I don't know of a real use-case for this and I don't want to over-complicate the spec. We can always add this in the future if we see a justification.